### PR TITLE
Add USB save backup support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,23 @@ Deep sleep is supported on compatible devices. Click the power button to enter d
 - Save states are stored in the `/.userdata/shared/PSP-ppsspp/` directory.
 - Game saves are stored in the `/Saves/PSP/` directory.
 
+### USB Save Backups
+
+You can back up your PSP saves and states to a USB drive without leaving MinUI.
+
+1. Plug in a USB drive. If the system does not auto-detect the mount path, create a file at `/.userdata/PSP-ppsspp/usb_mount_path` containing the absolute path to the USB mount point.
+2. Run the launcher with the `backup-saves` command:
+   ```
+   /Emus/<PLATFORM>/PSP.pak/launch.sh backup-saves
+   ```
+   To back up to a specific path (useful for testing), pass it as an argument:
+   ```
+   /Emus/<PLATFORM>/PSP.pak/launch.sh backup-saves /media/usb0
+   ```
+3. Backups are stored in `PSP_Backups/<timestamp>/` with separate `Saves/` and `States/` folders.
+
+The backup command can also be triggered from another MinUI launcher button by setting `params` to `backup-saves`.
+
 ## PPSSPP Configuration
 
 The PPSSPP configuration directory is located at `/Emus/<PLATFORM>/PSP.pak/PPSSPP/.config/ppsspp/`. This directory contains:

--- a/launch.sh
+++ b/launch.sh
@@ -26,6 +26,107 @@ export HOME="$EMU_DIR"
 PPSSPP_BIN="PPSSPPSDL"
 PPSSPP_INI="$EMU_DIR/.config/ppsspp/PSP/SYSTEM/ppsspp.ini"
 
+log() {
+    echo "[PSP] $*"
+}
+
+find_usb_mountpoint() {
+    CONFIG_PATH="$USERDATA_PATH/PSP-ppsspp/usb_mount_path"
+
+    if [ -f "$CONFIG_PATH" ]; then
+        CANDIDATE=$(head -n 1 "$CONFIG_PATH" | tr -d '\r')
+        if [ -n "$CANDIDATE" ] && [ -d "$CANDIDATE" ]; then
+            echo "$CANDIDATE"
+            return 0
+        fi
+        log "Configured USB path \"$CANDIDATE\" is not available."
+    fi
+
+    if [ ! -r /proc/mounts ]; then
+        log "Cannot read /proc/mounts to auto-detect USB mount point."
+        return 1
+    fi
+
+    while IFS=' ' read -r DEV MOUNT FS REST; do
+        case "$MOUNT" in
+            /media/*|/mnt/*|/run/media/*)
+                if echo "$MOUNT" | grep -qi usb; then
+                    echo "$MOUNT"
+                    return 0
+                fi
+                if echo "$DEV" | grep -qiE 'sd[a-z][0-9]*$|usb'; then
+                    echo "$MOUNT"
+                    return 0
+                fi
+            ;;
+        esac
+    done </proc/mounts
+
+    return 1
+}
+
+backup_saves_to_usb() {
+    DEST_ROOT="$1"
+
+    if [ -n "$DEST_ROOT" ]; then
+        if [ ! -d "$DEST_ROOT" ]; then
+            log "Destination \"$DEST_ROOT\" does not exist."
+            return 1
+        fi
+    else
+        DEST_ROOT=$(find_usb_mountpoint) || {
+            log "Unable to locate a USB mount point. Create $USERDATA_PATH/PSP-ppsspp/usb_mount_path with the desired destination if detection fails."
+            return 1
+        }
+    fi
+
+    TIMESTAMP=$(date +%Y%m%d-%H%M%S 2>/dev/null)
+    [ -n "$TIMESTAMP" ] || TIMESTAMP=$(date +%s 2>/dev/null)
+    [ -n "$TIMESTAMP" ] || TIMESTAMP="backup"
+
+    BACKUP_ROOT="$DEST_ROOT/PSP_Backups"
+    BACKUP_DIR="$BACKUP_ROOT/$TIMESTAMP"
+
+    if ! mkdir -p "$BACKUP_DIR"; then
+        log "Failed to create backup directory at $BACKUP_DIR."
+        return 1
+    fi
+
+    log "Backing up saves to $BACKUP_DIR."
+
+    STATUS=0
+
+    if [ -d "$SDCARD_PATH/Saves/PSP" ]; then
+        mkdir -p "$BACKUP_DIR/Saves" || STATUS=1
+        if ! cp -a "$SDCARD_PATH/Saves/PSP" "$BACKUP_DIR/Saves/" 2>/dev/null; then
+            log "Failed to copy game saves."
+            STATUS=1
+        fi
+    else
+        log "No game saves found at $SDCARD_PATH/Saves/PSP."
+    fi
+
+    if [ -d "$SHARED_USERDATA_PATH/PSP-ppsspp" ]; then
+        mkdir -p "$BACKUP_DIR/States" || STATUS=1
+        if ! cp -a "$SHARED_USERDATA_PATH/PSP-ppsspp" "$BACKUP_DIR/States/" 2>/dev/null; then
+            log "Failed to copy save states."
+            STATUS=1
+        fi
+    else
+        log "No save states found at $SHARED_USERDATA_PATH/PSP-ppsspp."
+    fi
+
+    sync
+
+    if [ "$STATUS" -eq 0 ]; then
+        log "Backed up saves to $BACKUP_DIR."
+    else
+        log "Backup completed with errors. Check the log for details. Destination: $BACKUP_DIR."
+    fi
+
+    return $STATUS
+}
+
 configure_aspect_ratio() {
     # Allow users to disable dynamic aspect ratio changes
     if [ -f "$USERDATA_PATH/PSP-ppsspp/no-aspect" ]; then
@@ -77,6 +178,16 @@ cleanup() {
 }
 
 main() {
+    case "$1" in
+        backup-saves)
+            shift
+            if backup_saves_to_usb "$1"; then
+                exit 0
+            fi
+            exit 1
+        ;;
+    esac
+
     echo "1" >/tmp/stay_awake
     trap "cleanup" EXIT INT TERM HUP QUIT
 

--- a/pak.json
+++ b/pak.json
@@ -1,6 +1,6 @@
 {
   "name": "PSP",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "type": "EMU",
   "description": "A Emu Pak for PSP, wrapping the standalone PPSSPP emulator.",
   "author": "ben16w",


### PR DESCRIPTION
## Summary
- add USB backup helper routines to launch script with logging and detection
- expose a `backup-saves` command for manual backups to USB or custom paths
- document the workflow in the README and bump the pak version to 4.2.0

## Testing
- `USERDATA_PATH=/tmp/userdata SDCARD_PATH=/tmp/sdcard SHARED_USERDATA_PATH=/tmp/shared LOGS_PATH=/tmp/logs ./launch.sh backup-saves /tmp/dest`