### PR TITLE
fix: correct PPSSPP paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,6 @@ This option can be found under Settings > Graphics > Speed Hacks > Skip buffer e
 
 ## License
 
-This project uses PPSSPP, which is open-source software. Please refer to the original PPSSPP [LICENSE.TXT](PPSSPPSDL/LICENSE.TXT) file for more details.
+This project uses PPSSPP, which is open-source software. Please refer to the original PPSSPP [LICENSE.TXT](PPSSPP/LICENSE.TXT) file for more details.
 
 The project code which is not part of PPSSPP is licensed under the [MIT License](https://opensource.org/licenses/MIT). See the project [LICENSE](LICENSE) file for more details.

--- a/pak.json
+++ b/pak.json
@@ -14,8 +14,8 @@
     "tg5050"
   ],
   "update_ignore": [
-    "PPSSPPSDL/.config/ppsspp/PSP/SYSTEM/controls.ini",
-    "PPSSPPSDL/.config/ppsspp/PSP/SYSTEM/ppsspp.ini"
+    "PPSSPP/.config/ppsspp/PSP/SYSTEM/controls.ini",
+    "PPSSPP/.config/ppsspp/PSP/SYSTEM/ppsspp.ini"
   ],
   "launch": "launch.sh"
 }


### PR DESCRIPTION
## Summary
- update `pak.json` `update_ignore` entries to point at `PPSSPP/.config/...`
- fix the README license link to use `PPSSPP/LICENSE.TXT`
- align stale path references with the current post-spruceUI directory layout

## Testing
- not run; changes are limited to metadata/documentation paths

_This pull request was created by an AI agent (OpenHands) on behalf of the user._