### PR TITLE
fix: switch PPSSPP assets to beta-main

### DIFF
--- a/.gitarchiveinclude
+++ b/.gitarchiveinclude
@@ -2,5 +2,4 @@ bin/minui-power-control
 bin/setalpha
 PPSSPP/PPSSPPSDL_tg5040
 PPSSPP/PPSSPPSDL_tg5050
-PPSSPP/libSDL2-2.0.so.0
 PPSSPP/libstdc++.so.6

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ dist
 bin/*
 PPSSPP/PPSSPPSDL_tg5040
 PPSSPP/PPSSPPSDL_tg5050
-PPSSPP/libSDL2-2.0.so.0
 
 !bin/.gitkeep
 PPSSPP/libstdc++.so.6

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PAK_NAME := $(shell jq -r .name pak.json)
 
 MINUI_POWER_CONTROL_VERSION := 1.1.0
-PPSSPP_RELEASE_URL := https://github.com/spruceUI/PPSSPP-spruce/releases/download/beta-main
+PPSSPP_RELEASE_URL := https://github.com/ben16w/PPSSPP-spruce/releases/download/beta-main
 SPRUCEOS_PSP_URL := https://raw.githubusercontent.com/spruceUI/spruceOS/main/Emu/PSP
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
 PAK_NAME := $(shell jq -r .name pak.json)
 
 MINUI_POWER_CONTROL_VERSION := 1.1.0
-PPSSPP_RELEASE_URL := https://github.com/spruceUI/PPSSPP-spruce/releases/download/latest
+PPSSPP_RELEASE_URL := https://github.com/spruceUI/PPSSPP-spruce/releases/download/beta-main
 SPRUCEOS_PSP_URL := https://raw.githubusercontent.com/spruceUI/spruceOS/main/Emu/PSP
 
 clean:
-	rm -f bin/minui-power-control bin/setalpha PPSSPP/PPSSPPSDL_tg5040 PPSSPP/PPSSPPSDL_tg5050 PPSSPP/libSDL2-2.0.so.0 PPSSPP/libstdc++.so.6
+	rm -f bin/minui-power-control bin/setalpha PPSSPP/PPSSPPSDL_tg5040 PPSSPP/PPSSPPSDL_tg5050 PPSSPP/libstdc++.so.6
 
 bump-version:
 	jq '.version = "$(RELEASE_VERSION)"' pak.json > pak.json.tmp
 	mv pak.json.tmp pak.json
 
-build: bin/minui-power-control bin/setalpha PPSSPP/PPSSPPSDL_tg5040 PPSSPP/PPSSPPSDL_tg5050 PPSSPP/libSDL2-2.0.so.0 PPSSPP/libstdc++.so.6
+build: bin/minui-power-control bin/setalpha PPSSPP/PPSSPPSDL_tg5040 PPSSPP/PPSSPPSDL_tg5050 PPSSPP/libstdc++.so.6
 	@echo "Build complete"
 
 bin/minui-power-control:
@@ -28,11 +28,8 @@ PPSSPP/PPSSPPSDL_tg5050:
 	chmod +x PPSSPP/PPSSPPSDL_tg5050
 
 bin/setalpha:
-	curl -f -o bin/setalpha -sSL $(PPSSPP_RELEASE_URL)/setalpha
+	curl -f -o bin/setalpha -sSL $(SPRUCEOS_PSP_URL)/setalpha
 	chmod +x bin/setalpha
-
-PPSSPP/libSDL2-2.0.so.0:
-	curl -f -o PPSSPP/libSDL2-2.0.so.0 -sSL $(PPSSPP_RELEASE_URL)/libSDL2-2.0.so.0
 
 PPSSPP/libstdc++.so.6:
 	curl -f -o PPSSPP/libstdc++.so.6 -sSL $(SPRUCEOS_PSP_URL)/libstdc%2B%2B.so.6


### PR DESCRIPTION
## Summary
- switch PPSSPP binary downloads from `latest` to `beta-main`
- pull `beta-main` binaries from `ben16w/PPSSPP-spruce`
- stop bundling `PPSSPP/libSDL2-2.0.so.0`
- fetch `setalpha` from `SPRUCEOS_PSP_URL` since the PPSSPP release does not publish it
